### PR TITLE
New Admin Page Showing Claimed Matches

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,3 +1,78 @@
-export default function Admin() {
-    return <p>Admin!</p>;
+import { db } from '../../../db/db';
+import { matchTable, teamTable, ticketRedemptionTable, MatchWithTeams } from '../../../db/schema';
+import { eq, aliasedTable } from 'drizzle-orm';
+import { clerkClient, User } from '@clerk/nextjs/server';
+import Match from '@/components/Match';
+
+const awayTeam = aliasedTable(teamTable, 'awayTeam');
+const homeTeam = aliasedTable(teamTable, 'homeTeam');
+
+type RedeemedMatch = MatchWithTeams & { user: User };
+
+export default async function Admin() {
+    const claimedMatches = await db
+        .select()
+        .from(ticketRedemptionTable)
+        .innerJoin(matchTable, eq(ticketRedemptionTable.matchId, matchTable.id))
+        .leftJoin(homeTeam, eq(matchTable.homeTeam, homeTeam.id))
+        .leftJoin(awayTeam, eq(matchTable.awayTeam, awayTeam.id));
+
+    //todo -- might want to consider writing new users into our
+    //todo -- neon database if this gets too heavy.
+
+    const client = clerkClient();
+
+    const matchesWithUsers = await Promise.all(
+        claimedMatches.map(async redemption => {
+            if (redemption.ticket_redemptions.claimedUserId) {
+                const maybeUser = await client.users.getUser(
+                    redemption.ticket_redemptions.claimedUserId
+                );
+
+                if (maybeUser) {
+                    return { ...redemption, user: maybeUser } as unknown as RedeemedMatch;
+                }
+
+                console.error(`User not found for match ${redemption.matches.matchKey}`);
+            }
+            return { ...redemption, user: null } as unknown as RedeemedMatch;
+        })
+    );
+
+    return (
+        <div className="match-detail-container">
+            <div className="match-detail-item">
+                <div>
+                    <h2 className="animated fadeInUp">
+                        Claimed Matches
+                        <ul>
+                            {matchesWithUsers.length > 0 ? (
+                                matchesWithUsers.map(match => (
+                                    <li key={match.matches.id} className="animated fadeInUp">
+                                        <div className="match-condensed-subheading medium-grey-text">
+                                            {match.user && match.user.emailAddresses.length
+                                                ? match.user.emailAddresses[0].emailAddress
+                                                : 'No Email Found'}
+                                        </div>
+                                        <Match
+                                            key={match.matches.id}
+                                            matchData={match.matches}
+                                            condensed
+                                            admin
+                                        />
+                                    </li>
+                                ))
+                            ) : (
+                                <div className="animated fadeInUp">
+                                    <h2 className="medium-grey-text">
+                                        No Matches Claimed at this Time
+                                    </h2>
+                                </div>
+                            )}
+                        </ul>
+                    </h2>
+                </div>
+            </div>
+        </div>
+    );
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -24,18 +24,16 @@ export default async function Admin() {
 
     const matchesWithUsers = await Promise.all(
         claimedMatches.map(async redemption => {
-            if (redemption.ticket_redemptions.claimedUserId) {
-                const maybeUser = await client.users.getUser(
-                    redemption.ticket_redemptions.claimedUserId
-                );
+            const { claimedUserId } = redemption.ticket_redemptions;
 
-                if (maybeUser) {
-                    return { ...redemption, user: maybeUser } as unknown as RedeemedMatch;
-                }
-
-                console.error(`User not found for match ${redemption.matches.matchKey}`);
+            if (!claimedUserId) {
+                //this should never happen
+                console.error(`no claimed user found for match: ${redemption.matches.matchKey}`);
+                return { ...redemption, user: null } as unknown as RedeemedMatch;
             }
-            return { ...redemption, user: null } as unknown as RedeemedMatch;
+
+            const maybeUser = await client.users.getUser(claimedUserId);
+            return { ...redemption, user: maybeUser ?? null } as unknown as RedeemedMatch;
         })
     );
 

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -52,7 +52,6 @@ export default function NavBar() {
                             <div className="nav-link">My Matches</div>
                         </Link>
                     </div>
-                    {/* //todo -- this doesn't work. */}
                     {user && user.publicMetadata.role === 'admin' ? (
                         <div className="nav-bar-item">
                             <Link href="/admin">


### PR DESCRIPTION
Create a down-and-dirty page for me to see what matches were claimed by users. This is currently a two-step process. We first must fetch claimed matches from the database which provides us with Clerk User IDs. We must then lookup users via the Clerk API in order to surface names + emails. 