### PR TITLE
update match lists with more accurate descriptions

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -4,7 +4,8 @@ import { eq, aliasedTable } from 'drizzle-orm';
 import { matchTable, teamTable, ticketRedemptionTable, MatchWithTeams } from '../../../db/schema';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
-import MatchList from '@/components/MatchList';
+import MatchGrid from '@/components/MatchGrid';
+import { buildMatch } from '@/utils/buildMatchForCard';
 
 const awayTeam = aliasedTable(teamTable, 'awayTeam');
 const homeTeam = aliasedTable(teamTable, 'homeTeam');
@@ -26,7 +27,7 @@ export default async function Profile() {
         return (
             <div>
                 {matchList.length > 0 ? (
-                    <MatchList matchData={matchList} />
+                    <MatchGrid matches={matchList.map(match => buildMatch(match, user))} />
                 ) : (
                     <div className="animated fadeInUp">
                         <h2 className="medium-grey-text"> You are not going to any matches</h2>

--- a/src/components/MatchList.tsx
+++ b/src/components/MatchList.tsx
@@ -56,7 +56,7 @@ export default async function MatchList({ matchData }: { matchData: MatchWithTea
                 <MatchGrid matches={availableGames} />
             </div>
             <div className="match-container p-6 sm:p-6">
-                <h3 className="nav-bar-subheading soft-grey-text">Previous Matches</h3>
+                <h3 className="nav-bar-subheading soft-grey-text">Unavailable Matches</h3>
             </div>
             <div className="max-w-7xl mx-auto py-2">
                 <MatchGrid matches={reservedGames} />

--- a/src/components/matches/RedeemedHeader.tsx
+++ b/src/components/matches/RedeemedHeader.tsx
@@ -3,7 +3,7 @@ export function RedeemedHeader() {
         <div className="rounded-xl bg-purple-50 shadow-sm ring-1 ring-purple-600 p-3 mb-8">
             <div className="flex flex-col items-center">
                 <span className="text-lg font-medium text-purple-500">
-                    You&aposre going to this match!
+                    You&apos;re going to this match!
                 </span>
             </div>
         </div>


### PR DESCRIPTION
This PR just fixes some grouping issues. If there aren't any tickets left, we move the match card into the "unavailable" group. But we labeled this group as "previous" matches, which wasn't entirely accurate. 