### PR TITLE
fix to allow SVG files to download, hopefully

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
+    dangerouslyAllowSVG: true,
+    contentDispositionType: 'attachment',
     remotePatterns: [{
       protocol: 'https',
       hostname: 'loremflickr.com'


### PR DESCRIPTION
Using Next.JS `<Image />` component, SVGs are not loaded by default so we have to set `dangerouslyAllowSVG` property to get them to load correctly. This is ok, because the SVGs are hosted in a private bucket and come from trusted sources. 