### PR TITLE
Fix mobile styling

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -34,3 +34,7 @@ You are an expert software developer specializing in TypeScript, React, [NextJS]
 - Avoid unnecessary else statements; use the if-return pattern instead.
 - Use guard clauses to handle preconditions and invalid states early.
 - Implement proper error logging and user-friendly error messages.
+
+# UI and Styling
+
+Use Tailwind CSS for components and styling and a mobile-first approach.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,7 +20,6 @@ export default function RootLayout({
 }: Readonly<{
     children: React.ReactNode;
 }>) {
-    //todo -- need to style all the login/logout stuff
     return (
         <ClerkProvider>
             <html lang="en">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
-import { ClerkProvider, SignedIn } from '@clerk/nextjs';
+import { ClerkProvider } from '@clerk/nextjs';
 import NavBar from '../components/NavBar';
 import Footer from '../components/Footer';
 import './globals.css';
@@ -11,7 +11,8 @@ const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
     title: 'Seattle Sounders Match Finder',
-    description: 'Grab some Seattle Sounders FC tickets!'
+    description: 'Grab some Seattle Sounders FC tickets!',
+    viewport: { width: 'device-width', initialScale: 1.0 }
 };
 
 export default function RootLayout({

--- a/src/components/matches/MatchHeader.tsx
+++ b/src/components/matches/MatchHeader.tsx
@@ -8,10 +8,10 @@ interface MatchHeaderProps {
 
 export function MatchHeader({ homeTeam, awayTeam }: MatchHeaderProps) {
     return (
-        <div className="rounded-xl bg-white shadow-sm ring-1 ring-gray-900/5 p-8 mb-8">
-            <div className="flex items-center justify-center gap-12">
-                <div className="text-center">
-                    <div className="w-32 h-32 relative mb-4">
+        <div className="rounded-xl bg-white shadow-sm ring-1 ring-gray-900/5 p-4 sm:p-8 mb-8">
+            <div className="flex flex-col sm:flex-row items-center justify-center gap-6 sm:gap-12">
+                <div className="text-center w-full sm:w-auto">
+                    <div className="w-24 h-24 sm:w-32 sm:h-32 relative mb-4 mx-auto">
                         <Image
                             src={homeTeam.img ?? ''}
                             alt={`${homeTeam.name} logo`}
@@ -19,16 +19,20 @@ export function MatchHeader({ homeTeam, awayTeam }: MatchHeaderProps) {
                             className="object-contain"
                         />
                     </div>
-                    <h2 className="text-xl font-semibold text-gray-900">{homeTeam.name}</h2>
+                    <h2 className="text-lg sm:text-xl font-semibold text-gray-900">
+                        {homeTeam.name}
+                    </h2>
                 </div>
 
-                <div className="flex flex-col items-center">
-                    <span className="text-sm font-medium text-gray-500 mb-2">VS</span>
-                    <div className="h-px w-16 bg-gray-200" />
+                <div className="flex flex-row sm:flex-col items-center">
+                    <span className="text-sm font-medium text-gray-500 mx-3 sm:mx-0 sm:mb-2">
+                        VS
+                    </span>
+                    <div className="h-px w-16 bg-gray-200 hidden sm:block" />
                 </div>
 
-                <div className="text-center">
-                    <div className="w-32 h-32 relative mb-4">
+                <div className="text-center w-full sm:w-auto">
+                    <div className="w-24 h-24 sm:w-32 sm:h-32 relative mb-4 mx-auto">
                         <Image
                             src={awayTeam.img ?? ''}
                             alt={`${awayTeam.name} logo`}
@@ -36,7 +40,9 @@ export function MatchHeader({ homeTeam, awayTeam }: MatchHeaderProps) {
                             className="object-contain"
                         />
                     </div>
-                    <h2 className="text-xl font-semibold text-gray-900">{awayTeam.name}</h2>
+                    <h2 className="text-lg sm:text-xl font-semibold text-gray-900">
+                        {awayTeam.name}
+                    </h2>
                 </div>
             </div>
         </div>

--- a/src/components/matches/TicketClaim.tsx
+++ b/src/components/matches/TicketClaim.tsx
@@ -110,7 +110,7 @@ export function TicketClaim({ matchId, ticketTiers, isLoggedIn }: TicketClaimPro
                                 <div className="flex items-center">
                                     <p className="text-sm font-medium text-gray-900">{tier.name}</p>
                                 </div>
-                                <div className="ml-4 flex items-center gap-x-4">
+                                <div className="ml-4 flex flex-col items-center gap-y-2 sm:gap-x-4 sm:flex-row">
                                     <span className="text-sm font-medium text-gray-900">
                                         ${(tier.price / 100).toFixed(2)}
                                     </span>

--- a/src/stories/MatchCard.stories.ts
+++ b/src/stories/MatchCard.stories.ts
@@ -47,23 +47,3 @@ export const Primary: Story = {
         match: testMatch
     }
 };
-
-// export const Secondary: Story = {
-//     args: {
-//         label: 'Button'
-//     }
-// };
-
-// export const Large: Story = {
-//     args: {
-//         size: 'large',
-//         label: 'Button'
-//     }
-// };
-
-// export const Small: Story = {
-//     args: {
-//         size: 'small',
-//         label: 'Button'
-//     }
-// };

--- a/src/stories/MatchHeader.stories.ts
+++ b/src/stories/MatchHeader.stories.ts
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { MatchHeader } from '../components/matches/MatchHeader';
+
+const testHeader = {
+    homeTeam: {
+        id: 1,
+        code: 'MU',
+        name: 'Manchester United',
+        img: 'https://loremflickr.com/640/480/sports?lock=730123202461696'
+    },
+    awayTeam: {
+        id: 2,
+        code: 'LVR',
+        name: 'Liverpool',
+        img: 'https://loremflickr.com/640/480/sports?lock=730123202461696'
+    }
+};
+
+const meta = {
+    title: 'MatchHeader',
+    component: MatchHeader,
+    parameters: {
+        layout: 'centered'
+    },
+    // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+    tags: ['autodocs'],
+    // More on argTypes: https://storybook.js.org/docs/api/argtypes
+    argTypes: {},
+    // Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked: https://storybook.js.org/docs/essentials/actions#action-args
+    args: { homeTeam: testHeader.homeTeam, awayTeam: testHeader.awayTeam }
+} satisfies Meta<typeof MatchHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+    args: {
+        homeTeam: testHeader.homeTeam,
+        awayTeam: testHeader.awayTeam
+    }
+};


### PR DESCRIPTION
This PR fixes mobile styling on the Match Detail page. Before the images wouldn't reflow to stack properly and the pill at the bottom of the page would break onto two lines, which was ok, but super ugly. 