### PR TITLE
Integrate Stripe checkout when purchasing tickets

### DIFF
--- a/.github/prompts/.prompts.md
+++ b/.github/prompts/.prompts.md
@@ -1,0 +1,44 @@
+You are an expert software developer specializing in TypeScript, React, [NextJS](https://nextjs.org/docs), [TailwindCSS](https://tailwindcss.com/), [Drizzle ORM](https://orm.drizzle.team/docs/overview), [Clerk](https://clerk.com/docs) and [Stripe](https://docs.stripe.com/).
+
+# Key conventions
+
+- You are familiar with the latest features and best practices.
+- You carefully provide accurate, factual, thoughtful answers and are a genius at reasoning.
+- You always write correct, up-to-date, bug-free, fully functional, working, secure, easy-to-read, and efficient code.
+- If there might not be a correct answer or do not know the answer, say so instead of guessing.
+
+# TypeScript usage
+
+- Use strict-mode TypeScript for all code; prefer interfaces over types.
+- Avoid enums; use const maps instead.
+- Strive for precise types. Look for type definitions in the codebase and create your own if none exist.
+- Avoid using type assertions like `as` or `!` unless absolutely necessary.
+- Use the `unknown` type instead of `any` when the type is truly unknown.
+- Use an object to pass multiple function params and to return results.
+- Leverage union types, intersection types, and conditional types for complex type definitions.
+- Use mapped types and utility types (e.g., `Partial<T>`, `Pick<T>`, `Omit<T>`) to transform existing types.
+- Implement generic types to create reusable, flexible type definitions.
+- Utilize the `keyof` operator and index access types for dynamic property access.
+- Implement discriminated unions for type-safe handling of different object shapes where appropriate.
+- Use the `infer` keyword in conditional types for type inference.
+- Leverage `readonly` properties for function parameter immutability.
+- Prefer narrow types whenever possible with `as const` assertions, `typeof`, `instanceof`, `satisfies`, and custom type guards.
+- Implement exhaustiveness checking using `never`.
+
+# Error handling and validation
+
+- Sanitize user input.
+- Handle errors and edge cases at the beginning of functions.
+- Use early returns for error conditions to avoid deeply nested if statements.
+- Place the happy path last in the function for improved readability.
+- Avoid unnecessary else statements; use the if-return pattern instead.
+- Use guard clauses to handle preconditions and invalid states early.
+- Implement proper error logging and user-friendly error messages.
+
+# UI and Styling
+
+Use Tailwind CSS for components and styling and a mobile-first approach.
+
+# Authentication and Authorization
+
+Use Clerk for all of our authentication and authorization in the application. 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,22 @@
 # season-ticket-tracker
+
 ⚽️ A small app to manage our extra season ticket. See it [here](https://seasontickets.me)
 
 ## Hosting & Deploy
-App hosted on Vercel and backed by a Neon SQL database. Auth by Clerk. 
+
+App hosted on Vercel and backed by a Neon SQL database. Auth by Clerk.
 
 ## Testing the Checkout Webhook
-When a customer purchases tickets through Stripe, a webhook is sent to `/api/stripe/webhook/` and we process the purchase and tie it to the user. 
 
-You can test this logic locally via the Stripe CLI. 
+When a customer purchases tickets through Stripe, a webhook is sent to `/api/stripe/webhook/` and we process the purchase and tie it to the user.
 
-1. First run `npm run stripe:listen` which will run the Stripe CLI and listen for any incoming webhook events. 
-2. Running the command from step one will provide you with a temporary `webhookSecret`. Save this secret and paste it into the `.env.local` file. 
-3. In another terminal, start the application with `npm run dev`. 
-4. In a third terminal, use the Stripe CLI to trigger the webhook even we listen for: 
+You can test this logic locally via the Stripe CLI.
+
+1. First run `npm run stripe:listen` which will run the Stripe CLI and listen for any incoming webhook events.
+2. Running the command from step one will provide you with a temporary `webhookSecret`. Save this secret and paste it into the `.env.local` file.
+3. In another terminal, start the application with `npm run dev`.
+4. In a third terminal, use the Stripe CLI to trigger the webhook even we listen for:
+
 ```bash
 stripe trigger checkout.session.completed \
 --add checkout_session:client_reference_id=[[MATCH_ID]] \            
@@ -20,3 +24,8 @@ stripe trigger checkout.session.completed \
 --override payment_method:"billing_details[email]"="[[EMAIL_ADDRESS]]"
 ```
 
+### Testing a Preview Deploy on Vercel
+
+When deploying to a Vercel preview environment, you'll need to turn off "Vercel Authentication" for the project. Vercel Authentication protects non-production environments and requires visitors to be logged into a Vercel account and part of our organization. Obviously, requests from Stripe won't have any type of authentication and we can't add custom headers to the Stripe request.
+
+Also, every deploy to vercel gets a unique domain, which means we need to update our webhook endpoint in Stripe after a deploy to a non-production environment.

--- a/README.md
+++ b/README.md
@@ -4,4 +4,19 @@
 ## Hosting & Deploy
 App hosted on Vercel and backed by a Neon SQL database. Auth by Clerk. 
 
+## Testing the Checkout Webhook
+When a customer purchases tickets through Stripe, a webhook is sent to `/api/stripe/webhook/` and we process the purchase and tie it to the user. 
+
+You can test this logic locally via the Stripe CLI. 
+
+1. First run `npm run stripe:listen` which will run the Stripe CLI and listen for any incoming webhook events. 
+2. Running the command from step one will provide you with a temporary `webhookSecret`. Save this secret and paste it into the `.env.local` file. 
+3. In another terminal, start the application with `npm run dev`. 
+4. In a third terminal, use the Stripe CLI to trigger the webhook even we listen for: 
+```bash
+stripe trigger checkout.session.completed \
+--add checkout_session:client_reference_id=[[MATCH_ID]] \            
+--add checkout_session:customer_email="[[EMAIL_ADDRESS]]" \
+--override payment_method:"billing_details[email]"="[[EMAIL_ADDRESS]]"
+```
 

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,4 +1,13 @@
-import { boolean, integer, pgTable, pgEnum, serial, text, timestamp } from 'drizzle-orm/pg-core';
+import {
+    boolean,
+    integer,
+    pgTable,
+    pgEnum,
+    serial,
+    text,
+    timestamp,
+    jsonb
+} from 'drizzle-orm/pg-core';
 
 export const matchTypeEnum = pgEnum('matchType', ['MLS', 'CWC', 'CONCACAF', 'USOC']);
 
@@ -56,7 +65,19 @@ export const ticketRedemptionTable = pgTable('ticket_redemptions', {
         .references(() => redemptionCodeTable.id),
     claimQty: integer('claim_qty').notNull(),
     claimedUserId: text('claimed_user_id'), //external uid
-    createdAt: timestamp('createdAt').defaultNow()
+    createdAt: timestamp('createdAt').defaultNow(),
+    stripeEventId: integer('stripe_event_id').references(() => stripeWebhookEventsTable.id)
+});
+
+export const stripeWebhookEventsTable = pgTable('stripe_webhook_events', {
+    id: serial('id').primaryKey(),
+    eventId: text('event_id').notNull(),
+    objectId: text('object_id').notNull(),
+    eventType: text('event_type').notNull(),
+    createdAt: timestamp('createdAt').defaultNow(),
+    updatedAt: timestamp('updatedAt'),
+    processedOk: boolean('processed_ok').notNull().default(false),
+    eventBody: jsonb('event_body').notNull()
 });
 
 export type InsertTicketRedemption = typeof ticketRedemptionTable.$inferInsert;
@@ -76,6 +97,9 @@ export type SelectAppAlert = typeof appAlertTable.$inferSelect;
 
 export type InsertMatch = typeof matchTable.$inferInsert;
 export type SelectMatch = typeof matchTable.$inferSelect;
+
+export type InsertStripeEvent = typeof stripeWebhookEventsTable.$inferInsert;
+export type SelectStripeEvent = typeof stripeWebhookEventsTable.$inferSelect;
 
 export type MatchWithTeams = {
     matches: SelectMatch;

--- a/migrations/0008_windy_lenny_balinger.sql
+++ b/migrations/0008_windy_lenny_balinger.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS "stripe_webhook_events" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"object_id" text NOT NULL,
+	"event_type" text NOT NULL,
+	"createdAt" timestamp DEFAULT now(),
+	"updatedAt" timestamp,
+	"processed_ok" boolean DEFAULT false NOT NULL,
+	"event_body" jsonb NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "ticket_redemptions" ADD COLUMN "stripe_event_id" integer;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "ticket_redemptions" ADD CONSTRAINT "ticket_redemptions_stripe_event_id_stripe_webhook_events_id_fk" FOREIGN KEY ("stripe_event_id") REFERENCES "public"."stripe_webhook_events"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/migrations/0009_right_silver_surfer.sql
+++ b/migrations/0009_right_silver_surfer.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "stripe_webhook_events" ADD COLUMN "event_id" text NOT NULL;

--- a/migrations/meta/0008_snapshot.json
+++ b/migrations/meta/0008_snapshot.json
@@ -1,0 +1,429 @@
+{
+  "id": "9c3bae31-a588-4015-bb34-fb5dd1baf3ef",
+  "prevId": "ce3524e5-6e4f-46e2-9ef0-dd7389b1baa7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admins": {
+      "name": "admins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "external_uid": {
+          "name": "external_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admins_external_uid_unique": {
+          "name": "admins_external_uid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_uid"
+          ]
+        },
+        "admins_email_unique": {
+          "name": "admins_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    },
+    "public.app_alerts": {
+      "name": "app_alerts",
+      "schema": "",
+      "columns": {
+        "should_display": {
+          "name": "should_display",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "message_header": {
+          "name": "message_header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_text": {
+          "name": "message_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.matches": {
+      "name": "matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "match_key": {
+          "name": "match_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "away_team": {
+          "name": "away_team",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_team": {
+          "name": "home_team",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_user_id": {
+          "name": "claimed_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matchType": {
+          "name": "matchType",
+          "type": "matchType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qty_tickets_available": {
+          "name": "qty_tickets_available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ticket_price": {
+          "name": "ticket_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "matches_away_team_teams_id_fk": {
+          "name": "matches_away_team_teams_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "away_team"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_home_team_teams_id_fk": {
+          "name": "matches_home_team_teams_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "home_team"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.redemption_codes": {
+      "name": "redemption_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "redemption_codes_code_unique": {
+          "name": "redemption_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      }
+    },
+    "public.stripe_webhook_events": {
+      "name": "stripe_webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_ok": {
+          "name": "processed_ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "event_body": {
+          "name": "event_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MLS'"
+        },
+        "img": {
+          "name": "img",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.ticket_redemptions": {
+      "name": "ticket_redemptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redemption_code_id": {
+          "name": "redemption_code_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_qty": {
+          "name": "claim_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_user_id": {
+          "name": "claimed_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "stripe_event_id": {
+          "name": "stripe_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ticket_redemptions_match_id_matches_id_fk": {
+          "name": "ticket_redemptions_match_id_matches_id_fk",
+          "tableFrom": "ticket_redemptions",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ticket_redemptions_redemption_code_id_redemption_codes_id_fk": {
+          "name": "ticket_redemptions_redemption_code_id_redemption_codes_id_fk",
+          "tableFrom": "ticket_redemptions",
+          "tableTo": "redemption_codes",
+          "columnsFrom": [
+            "redemption_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ticket_redemptions_stripe_event_id_stripe_webhook_events_id_fk": {
+          "name": "ticket_redemptions_stripe_event_id_stripe_webhook_events_id_fk",
+          "tableFrom": "ticket_redemptions",
+          "tableTo": "stripe_webhook_events",
+          "columnsFrom": [
+            "stripe_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.matchType": {
+      "name": "matchType",
+      "schema": "public",
+      "values": [
+        "MLS",
+        "CWC",
+        "CONCACAF",
+        "USOC"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/0009_snapshot.json
+++ b/migrations/meta/0009_snapshot.json
@@ -1,0 +1,435 @@
+{
+  "id": "66acf4df-bdba-437e-87c3-39fda7add848",
+  "prevId": "9c3bae31-a588-4015-bb34-fb5dd1baf3ef",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admins": {
+      "name": "admins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "external_uid": {
+          "name": "external_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admins_external_uid_unique": {
+          "name": "admins_external_uid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_uid"
+          ]
+        },
+        "admins_email_unique": {
+          "name": "admins_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    },
+    "public.app_alerts": {
+      "name": "app_alerts",
+      "schema": "",
+      "columns": {
+        "should_display": {
+          "name": "should_display",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "message_header": {
+          "name": "message_header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_text": {
+          "name": "message_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.matches": {
+      "name": "matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "match_key": {
+          "name": "match_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "away_team": {
+          "name": "away_team",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_team": {
+          "name": "home_team",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_user_id": {
+          "name": "claimed_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matchType": {
+          "name": "matchType",
+          "type": "matchType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qty_tickets_available": {
+          "name": "qty_tickets_available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ticket_price": {
+          "name": "ticket_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "matches_away_team_teams_id_fk": {
+          "name": "matches_away_team_teams_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "away_team"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_home_team_teams_id_fk": {
+          "name": "matches_home_team_teams_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "home_team"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.redemption_codes": {
+      "name": "redemption_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "redemption_codes_code_unique": {
+          "name": "redemption_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      }
+    },
+    "public.stripe_webhook_events": {
+      "name": "stripe_webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_ok": {
+          "name": "processed_ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "event_body": {
+          "name": "event_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MLS'"
+        },
+        "img": {
+          "name": "img",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.ticket_redemptions": {
+      "name": "ticket_redemptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redemption_code_id": {
+          "name": "redemption_code_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_qty": {
+          "name": "claim_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_user_id": {
+          "name": "claimed_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "stripe_event_id": {
+          "name": "stripe_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ticket_redemptions_match_id_matches_id_fk": {
+          "name": "ticket_redemptions_match_id_matches_id_fk",
+          "tableFrom": "ticket_redemptions",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ticket_redemptions_redemption_code_id_redemption_codes_id_fk": {
+          "name": "ticket_redemptions_redemption_code_id_redemption_codes_id_fk",
+          "tableFrom": "ticket_redemptions",
+          "tableTo": "redemption_codes",
+          "columnsFrom": [
+            "redemption_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ticket_redemptions_stripe_event_id_stripe_webhook_events_id_fk": {
+          "name": "ticket_redemptions_stripe_event_id_stripe_webhook_events_id_fk",
+          "tableFrom": "ticket_redemptions",
+          "tableTo": "stripe_webhook_events",
+          "columnsFrom": [
+            "stripe_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.matchType": {
+      "name": "matchType",
+      "schema": "public",
+      "values": [
+        "MLS",
+        "CWC",
+        "CONCACAF",
+        "USOC"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -57,6 +57,20 @@
       "when": 1737231561304,
       "tag": "0007_melodic_cerebro",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1741040775081,
+      "tag": "0008_windy_lenny_balinger",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1741041251451,
+      "tag": "0009_right_silver_surfer",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "next": "14.2.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "stripe": "^17.7.0",
         "ws": "^8.18.0"
       },
       "devDependencies": {
@@ -6153,7 +6154,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
       "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -6166,7 +6166,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
       "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
-      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "get-intrinsic": "^1.2.6"
@@ -7234,7 +7233,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -7416,7 +7414,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -7425,7 +7422,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -7485,7 +7481,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
       "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -8371,7 +8366,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -8416,7 +8410,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
       "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
-      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-define-property": "^1.0.1",
@@ -8440,7 +8433,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -8608,7 +8600,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -8673,7 +8664,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -8723,7 +8713,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -9799,7 +9788,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -10226,7 +10214,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -11212,7 +11199,6 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
-      "dev": true,
       "dependencies": {
         "side-channel": "^1.1.0"
       },
@@ -12067,7 +12053,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
@@ -12086,7 +12071,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3"
@@ -12102,7 +12086,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -12120,7 +12103,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -12568,6 +12550,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-17.7.0.tgz",
+      "integrity": "sha512-aT2BU9KkizY9SATf14WhhYVv2uOapBWX0OFWF4xvcj1mPaNotlSc2CsxpS4DS46ZueSppmCF5BX1sNYBtwBvfw==",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
       }
     },
     "node_modules/style-loader": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "db:migrate": "npx drizzle-kit migrate",
     "db:push-dangerous": "npx drizzle-kit push",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "stripe:listen": "stripe listen --forward-to localhost:3000/api/stripe/webhook"
   },
   "dependencies": {
     "@clerk/nextjs": "^5.6.0",
@@ -25,6 +26,7 @@
     "next": "14.2.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "stripe": "^17.7.0",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -1,0 +1,124 @@
+import Stripe from 'stripe';
+import { db } from '../../../../../db/db';
+import { matchTable, redemptionCodeTable, ticketRedemptionTable } from '../../../../../db/schema';
+import { eq } from 'drizzle-orm';
+import { clerkClient, User } from '@clerk/nextjs/server';
+
+interface ClaimTicketParams {
+    matchId: number;
+    customerEmail: string;
+}
+
+const STRIPE_REDEMPTION_CODE = 'stripe_redemption';
+
+async function claimTicket({ matchId, customerEmail }: ClaimTicketParams) {
+    //need to lookup the user by their email. Maybe we should actually pass the user id
+    //can we pass a JSON string as the customer reference?
+    const client = clerkClient();
+    const maybeUsers = await client.users.getUserList({ emailAddress: [customerEmail] });
+    const [match] = await db.select().from(matchTable).where(eq(matchTable.id, matchId));
+
+    if (maybeUsers.totalCount <= 0) {
+        console.error(`no users found with email: ${customerEmail}`);
+        throw new Error(`Could not find user with email: ${customerEmail}`);
+    }
+
+    if (maybeUsers.totalCount > 1) {
+        //this shouldn't really happen, but it's still a possibility.
+        console.warn(`more than one user found with email ${customerEmail}. Selecting first one.`);
+    }
+
+    if (!match) {
+        console.error(`${matchId} not found.`);
+        throw new Error(`Match not found: ${matchId}`);
+    }
+
+    const claimQty = 1;
+    let newTicketQty = match.qtyTicketsAvailable;
+
+    if (match.qtyTicketsAvailable > 0) {
+        newTicketQty = match.qtyTicketsAvailable - claimQty;
+    } else {
+        console.error(`${matchId} does not have any tickets available.`);
+        throw new Error(`No tickets available for match ${matchId}`);
+    }
+
+    const [dbRedemptionCode] = await db
+        .select()
+        .from(redemptionCodeTable)
+        .where(eq(redemptionCodeTable.code, STRIPE_REDEMPTION_CODE));
+
+    await db.transaction(async tx => {
+        await tx
+            .update(matchTable)
+            .set({
+                available: newTicketQty > 0,
+                //todo -- this column should get dropped.
+                //todo -- multiple users could claim tickets for a match.
+                claimedUserId: maybeUsers.data[0].id,
+                qtyTicketsAvailable: newTicketQty
+            })
+            .where(eq(matchTable.id, matchId));
+
+        await tx.insert(ticketRedemptionTable).values({
+            matchId,
+            claimedUserId: maybeUsers.data[0].id,
+            claimQty,
+            redemptionCodeId: dbRedemptionCode.id
+        });
+    });
+}
+
+export async function POST(request: Request) {
+    const secretKey = process.env.STRIPE_SECRET_KEY;
+    const endpointSecret = process.env.STRIPE_ENDPOINT_SECRET;
+
+    if (!secretKey) {
+        console.error(`No publishable key, could not init Stripe library`);
+        return new Response('Failure', { status: 500 });
+    }
+
+    if (!endpointSecret) {
+        console.error(`No endpoint secrete, could not validate webhook payload`);
+        return new Response('Failure', { status: 500 });
+    }
+
+    const stripe = new Stripe(secretKey);
+
+    const sig = request.headers.get('Stripe-Signature') ?? '';
+    const body = await request.text();
+
+    let event;
+    try {
+        event = stripe.webhooks.constructEvent(body, sig, endpointSecret);
+    } catch (err: unknown) {
+        const knownErr = err as Error;
+        console.error(`Error validating webhook: ${knownErr.message}`);
+        return new Response(`${knownErr.message}`, { status: 400 });
+    }
+
+    switch (event.type) {
+        case 'checkout.session.completed':
+            const data = event.data.object;
+            console.log(`Client Reference ${data.client_reference_id}`);
+            console.log(`Client Email: ${data.customer_email}`);
+            try {
+                //todo -- check if we've handled this event before
+                claimTicket({
+                    matchId: Number(data.client_reference_id),
+                    customerEmail: data.customer_email ?? ''
+                });
+                //todo -- write event to table so we don't process duplicates
+            } catch (err) {
+                const knownErr = err as Error;
+                return new Response(`Failure: ${knownErr.message}`, { status: 400 });
+            }
+
+            break;
+        default:
+            console.log(`Unhandled event type: ${event.type}`);
+            break;
+    }
+
+    return new Response('Success!', { status: 200 });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata, Viewport } from 'next';
+
 import { Inter } from 'next/font/google';
 import { ClerkProvider } from '@clerk/nextjs';
+import Script from 'next/script';
 import NavBar from '../components/NavBar';
 import Footer from '../components/Footer';
 import './globals.css';
@@ -28,6 +30,7 @@ export default function RootLayout({
         <ClerkProvider>
             <html lang="en">
                 <body>
+                    <Script src="https://js.stripe.com/v3/pricing-table.js" />
                     <NavBar />
                     {children}
                     <Footer />

--- a/src/app/matches/[id]/page.tsx
+++ b/src/app/matches/[id]/page.tsx
@@ -66,6 +66,7 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
                     dateTime={matchMapped.timestamp}
                     location={matchMapped.location ?? 'Unknown venue'}
                 />
+
                 <TicketClaim
                     matchId={matchMapped.id}
                     ticketTiers={matchMapped.ticketTiers}

--- a/src/components/matches/StripeClaim.tsx
+++ b/src/components/matches/StripeClaim.tsx
@@ -24,7 +24,7 @@ const StripeCheckout: FC<StripCheckoutProps> = ({ matchId }) => {
         return <></>;
     }
 
-    if (user.emailAddresses.length <= 0) {
+    if (!user || user.emailAddresses.length <= 0) {
         console.error('user found, but no email was attached to the account');
         return <></>;
     }

--- a/src/components/matches/StripeClaim.tsx
+++ b/src/components/matches/StripeClaim.tsx
@@ -1,0 +1,42 @@
+'use client';
+import { FC } from 'react';
+import { useUser } from '@clerk/nextjs';
+
+interface StripCheckoutProps {
+    matchId: number;
+}
+
+const StripeCheckout: FC<StripCheckoutProps> = ({ matchId }) => {
+    const pricingTableId: string | null = process.env.NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID ?? null;
+    const publishableKey: string | null = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? null;
+    const { isSignedIn, user, isLoaded } = useUser();
+
+    if (!isLoaded) {
+        return <div>Loading</div>;
+    }
+    if (!pricingTableId || !publishableKey) {
+        console.error('Stripe keys not configured');
+        return <></>;
+    }
+
+    if (!isSignedIn) {
+        console.error('no user found');
+        return <></>;
+    }
+
+    if (user.emailAddresses.length <= 0) {
+        console.error('user found, but no email was attached to the account');
+        return <></>;
+    }
+
+    return (
+        <stripe-pricing-table
+            pricing-table-id={`${pricingTableId}`}
+            publishable-key={`${publishableKey}`}
+            customer-email={`${user.emailAddresses[0].emailAddress}`}
+            client-reference-id={`${matchId}`}
+        ></stripe-pricing-table>
+    );
+};
+
+export default StripeCheckout;

--- a/src/components/matches/TicketClaim.tsx
+++ b/src/components/matches/TicketClaim.tsx
@@ -3,6 +3,7 @@
 import { ChangeEvent, FormEvent, useState } from 'react';
 import { TicketTier } from '../../../types/match';
 import { validateAndClaimTicket } from '@/actions/redeemMatch';
+import StripeCheckout from './StripeClaim';
 
 interface TicketClaimProps {
     matchId: number;
@@ -11,6 +12,9 @@ interface TicketClaimProps {
 }
 
 export function TicketClaim({ matchId, ticketTiers, isLoggedIn }: TicketClaimProps) {
+    const useStripeCheckout = process.env.NEXT_PUBLIC_USE_STRIPE === 'true';
+
+    console.log('useStripeCheckout ', useStripeCheckout);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [redemptionCode, setRedemptionCode] = useState('');
     const [redemptionMessage, setRedemptionMessage] = useState('');
@@ -61,6 +65,10 @@ export function TicketClaim({ matchId, ticketTiers, isLoggedIn }: TicketClaimPro
             );
         }
 
+        if (useStripeCheckout) {
+            return <></>;
+        }
+
         return anyTicketsAvailable(ticketTiers) ? (
             <form onSubmit={e => handleClaimTicket(e)} className="space-y-6">
                 <div>
@@ -104,29 +112,38 @@ export function TicketClaim({ matchId, ticketTiers, isLoggedIn }: TicketClaimPro
 
     return (
         <div className="rounded-xl bg-white shadow-sm ring-1 ring-gray-900/5">
-            <div className="border-b border-gray-200 p-8">
+            <div className={`${useStripeCheckout ? '' : 'border-b'} border-gray-200 p-8`}>
                 <h3 className="text-base font-semibold leading-7 text-gray-900">
                     Available Tickets
                 </h3>
-                <div className="mt-6 flow-root">
-                    <ul className="-my-2 divide-y divide-gray-100">
-                        {ticketTiers.map(tier => (
-                            <li key={tier.id} className="flex items-center justify-between py-2">
-                                <div className="flex items-center">
-                                    <p className="text-sm font-medium text-gray-900">{tier.name}</p>
-                                </div>
-                                <div className="ml-4 flex flex-col items-center gap-y-2 sm:gap-x-4 sm:flex-row">
-                                    <span className="text-sm font-medium text-gray-900">
-                                        ${(tier.price / 100).toFixed(2)}
-                                    </span>
-                                    <span className="inline-flex items-center rounded-full bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20">
-                                        {tier.availableCount} available
-                                    </span>
-                                </div>
-                            </li>
-                        ))}
-                    </ul>
-                </div>
+                {useStripeCheckout && isLoggedIn ? (
+                    <StripeCheckout matchId={matchId} />
+                ) : (
+                    <div className="mt-6 flow-root">
+                        <ul className="-my-2 divide-y divide-gray-100">
+                            {ticketTiers.map(tier => (
+                                <li
+                                    key={tier.id}
+                                    className="flex items-center justify-between py-2"
+                                >
+                                    <div className="flex items-center">
+                                        <p className="text-sm font-medium text-gray-900">
+                                            {tier.name}
+                                        </p>
+                                    </div>
+                                    <div className="ml-4 flex flex-col items-center gap-y-2 sm:gap-x-4 sm:flex-row">
+                                        <span className="text-sm font-medium text-gray-900">
+                                            ${(tier.price / 100).toFixed(2)}
+                                        </span>
+                                        <span className="inline-flex items-center rounded-full bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20">
+                                            {tier.availableCount} available
+                                        </span>
+                                    </div>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                )}
             </div>
 
             <div className="p-8">{generateClaimForm()}</div>

--- a/src/components/matches/TicketClaim.tsx
+++ b/src/components/matches/TicketClaim.tsx
@@ -116,7 +116,7 @@ export function TicketClaim({ matchId, ticketTiers, isLoggedIn }: TicketClaimPro
                 <h3 className="text-base font-semibold leading-7 text-gray-900">
                     Available Tickets
                 </h3>
-                {useStripeCheckout && isLoggedIn ? (
+                {useStripeCheckout && isLoggedIn && anyTicketsAvailable(ticketTiers) ? (
                     <StripeCheckout matchId={matchId} />
                 ) : (
                     <div className="mt-6 flow-root">

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -10,6 +10,19 @@ declare global {
         };
     }
 
+    namespace NodeJS {
+        interface ProcessEnv {
+            DATABASE_URL: string;
+            NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: string;
+            CLERK_SECRET_KEY: string;
+            TZ: string;
+            NEXT_PUBLIC_USE_STRIPE: string;
+            NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: string;
+            NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID: string;
+            STRIPE_ENDPOINT_SECRET: string;
+            STRIPE_SECRET_KEY: string;
+        }
+    }
     namespace JSX {
         interface IntrinsicElements {
             'stripe-pricing-table': React.DetailedHTMLProps<

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -9,4 +9,13 @@ declare global {
             role?: Roles;
         };
     }
+
+    namespace JSX {
+        interface IntrinsicElements {
+            'stripe-pricing-table': React.DetailedHTMLProps<
+                React.HTMLAttributes<HTMLElement>,
+                HTMLElement
+            >;
+        }
+    }
 }


### PR DESCRIPTION
This PR adds basic support for Stripe, which involved a few things: 
-  Adjusting frontend logic and adding Stripe components, behind a feature flag. The main work is here is in `src/components/matches/StripeClaim.tsx` and `src/components/matches/TicketClaim.tsx`
-  Adding support to receive stripe webhooks when users complete checkout, allowing us to update the match as necessary. For this we needed to add a new table to track Stripe events and an API route handler to accept incoming requests. 
    -  New table schema: `db/schema.ts`
    - Migrations that need to be run before deploy: `migrations/0008_windy_lenny_balinger.sql` and `migrations/0009_right_silver_surfer.sql`
    - Route handler (with a lot of logic duplicated from the `RedeemMatch.ts` action: `src/app/api/stripe/webhook/route.ts`
- New environment variables that will need to be added to the deployment: 
    -  `NEXT_PUBLIC_USE_STRIPE`: Feature flag to turn the stripe integration on or off. 
    -  `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`: Stripe publishable key. This is visible from the frontend (and that's ok). 
    -  `NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID`: The Stripe pricing table where our products + pricing data are held. 
    -  `STRIPE_ENDPOINT_SECRET`: The Stripe endpoint secret that we can use to validate webhook requests. **Keep this secret!**
    -  `STRIPE_SECRET_KEY`: The Stripe API key to make requests via the Stripe API. **Also keep this secret.**
- There was also some random clean-up that, ideally, should've been in a completely separate PR:
    - New `.github/prompts/` directory and `.prompts.md` file for Github Copilot
    - Changes to the Node `Process` type to handle the expected ENV vars
